### PR TITLE
Add category mapping for user-friendly display

### DIFF
--- a/Ecommerce/Views/RegisteredRollNumbers/Index.cshtml
+++ b/Ecommerce/Views/RegisteredRollNumbers/Index.cshtml
@@ -5,7 +5,15 @@
     Layout = "~/Views/Shared/_Layout.cshtml";
 }
 
+@{
+    var categoryNames = new Dictionary<string, string>
+    {
+        { "A", "Prime" },
+        { "B", "Ultimate" },
+        { "C", "Ultimate Plus" }
+    };
 }
+
 <div class="container-fluid">
     <div class="row justify-content-center align-items-center" style="min-height: 100vh;background: linear-gradient(to right, #1f1f2e, #29293d, #3a2b4f);">
         <div class="col-md-6">
@@ -44,7 +52,10 @@
                                     @Html.DisplayFor(modelItem => item.RollNumber)
                                 </td>
                                 <td>
-                                    @Html.DisplayFor(modelItem => item.Category)
+                                    @if (!string.IsNullOrEmpty(item.Category) && categoryNames.TryGetValue(item.Category, out var friendlyName))
+                                    {
+                                        @Html.DisplayFor(modelItem => @friendlyName)
+                                    }
                                 </td>
                                 <td>
                                     @Html.DisplayFor(modelItem => item.RegistrationDate)


### PR DESCRIPTION
Introduces a `categoryNames` dictionary to map category keys ("A", "B", "C") to friendly names ("Prime", "Ultimate", "Ultimate Plus"). Updates the display logic in the table to show these friendly names instead of the original category values when available.