### PR TITLE
Update admin email config with placeholder values

### DIFF
--- a/Ecommerce/appsettings.Production.json
+++ b/Ecommerce/appsettings.Production.json
@@ -20,10 +20,10 @@
   //"Email": {
   //  "SmtpHost": "smtp.zoho.com",
   //  "Port": "587",
-  //  "Username": "warranty@motoprotekt.de",
-  //  "Password": "19@July1993",
-  //  "From": "warranty@motoprotekt.de",
-  //  "AdminEmail": "warranty@motoprotekt.de"
+  //  "Username": "warranty@fake.",
+  //  "Password": "fake",
+  //  "From": "warranty@fake",
+  //  "AdminEmail": "warranty@fake"
   //},
   "ADMIN1_EMAIL": "nada.fcai@gmail.com",
   "ADMIN1_USERNAME": "nadaabutaleb",


### PR DESCRIPTION
Replaced original email settings in `appsettings.Production.json` with new placeholder values for "Username", "Password", "From", and "AdminEmail". This change is intended for testing purposes and removes the previous real credentials.